### PR TITLE
Adding count method

### DIFF
--- a/src/array-linq.js
+++ b/src/array-linq.js
@@ -135,3 +135,24 @@ Array.method('last', function (spec) {
         
     return last;
 });
+
+
+Array.method('count', function (spec) {
+    var count = 0,
+    arrayLength = 0;
+    if(this !== null){     
+        arrayLength = this.length;   
+        if(spec === undefined){
+            count = arrayLength;
+        }
+        else{           
+            for (var x = 0; x < arrayLength; x = x + 1) {
+                if(spec(this[x])){
+                    count = count + 1
+                }
+            }        
+        }
+    }
+        
+    return count;
+});

--- a/tests/array-linq-count-test.js
+++ b/tests/array-linq-count-test.js
@@ -1,0 +1,41 @@
+//debug: mocha tests --recursive --watch --debug-brk
+var chai = require('chai');
+var expect = chai.expect;
+require('./../src/array-linq');
+
+var children = [
+
+    { name: 'ana', sex: 'f' },
+    { name: 'fosto', sex: 'm' },
+    { name: 'jane', sex: 'f' },
+    { name: 'yadi', sex: 'f' },
+    { name: 'lili', sex: 'f' },
+    { name: 'bany', sex: 'm' },
+    { name: 'rod', sex: null },
+    { name: 'auro', sex: 'f' },
+    { name: 'martin', sex: 'm' }
+],
+    messageList = [];
+
+
+describe('array extension methods count', function () {
+    afterEach(function () {
+        kid = null;
+    });
+
+    it('should count(spec) return array lenght if no specification added', function () {
+        var childrenNumber = children
+            .count();
+        
+        console.log(childrenNumber);
+        expect(childrenNumber).to.equal(9);
+    });
+
+    it('should count(spec) return the number of elements that accomplish the specification added', function () {       
+         var childrenNumber = children
+            .count(child => child.sex === 'f');
+        
+        console.log(childrenNumber);
+        expect(childrenNumber).to.equal(5);
+    });
+});


### PR DESCRIPTION
**Adding count method:** 
Will return the number of elements on the collection that satisfies the specification, if no specification is present then it will return just the array’s length property. You may produce the same result using the where() method and then testing the length property, but the count() method must not create a new collection as the where() method does.
Example

- var numChildren = children.count();
- var numBoys = children.count(child => child.sex === 'm')
