### PR TITLE
Adding StringBuilder cat method

### DIFF
--- a/src/stringBuilder.js
+++ b/src/stringBuilder.js
@@ -13,6 +13,9 @@ StringBuilder = (function () {
         },
         clear: function () {
             buffer = [];
+        },
+        string: function () {
+            return buffer.join('');
         }
     };
 } ());

--- a/src/stringBuilder.js
+++ b/src/stringBuilder.js
@@ -5,7 +5,7 @@ StringBuilder = (function () {
 
     return {
         cat: function (...val) {
-            val.flatten().each(obj => typeof obj === "function" ? buffer.push(obj()) : buffer.push(obj));
+            val.flatten().each(obj => { typeof obj === "function" ? buffer.push(obj()) : buffer.push(obj) });
             return this;
         },
         len: function () {

--- a/tests/stringBuilder/stringBuilder-cat-test.js
+++ b/tests/stringBuilder/stringBuilder-cat-test.js
@@ -32,7 +32,7 @@ describe('StringBuilder method cat', () => {
 
     it('should be able of add the result of a function', () => {
 
-        expect(sb.cat('Hello ', () => 'World').len()).to.equal(5)
+        expect(sb.cat('Hello ', () => 'World').len()).to.equal(2)
     });
 
 });

--- a/tests/stringBuilder/stringBuilder-string-test.js
+++ b/tests/stringBuilder/stringBuilder-string-test.js
@@ -1,0 +1,13 @@
+var chai = require('chai');
+var expect = chai.expect;
+var StringBuilder = require('./../../src/stringBuilder');
+
+var sb = StringBuilder
+
+
+describe('StringBuilder method string', () => {
+    
+    it('should return the buffer concatenated', () => {
+        expect(sb.cat('Hello ', 'World', ' !!!').string()).to.equal('Hello World !!!');
+    });
+});


### PR DESCRIPTION
**_Adding StringBuilder_**
`cat(arg1, arg2,..., argN) method: `
```
This will be the most frequently used method, it allows the addition of one or many 
strings to the buffer
```

- [ Regular use ] 
`sb.cat('Hello World')`
`sb.cat('Hello ').cat('this ')`

- [ Function as parameters ] 
`sb.cat('Hello ', () => 'World')`

- [ Array as parameter ] 
`sb.cat(['Hello ', 'World'])`
`sb.cat('Hello ', ['World'])`
