### PR TITLE
StringBuider adding catIf method

### DIFF
--- a/src/stringBuilder.js
+++ b/src/stringBuilder.js
@@ -23,6 +23,12 @@ StringBuilder = (function () {
                 this.cat(val);
             }
             return this;
+        },
+        catIf(flag, ...val){
+            if(flag){
+                this.cat(val);
+            }
+            return this;
         }
     };
 } ());

--- a/tests/stringBuilder/stringBuilder-catIf-test.js
+++ b/tests/stringBuilder/stringBuilder-catIf-test.js
@@ -1,0 +1,23 @@
+var chai = require('chai');
+var expect = chai.expect;
+var StringBuilder = require('./../../src/stringBuilder');
+
+var sb = StringBuilder
+
+
+describe('StringBuilder method catIf', () => {
+    
+    afterEach(() => {
+        sb.clear();
+    });
+
+    it('should add an string howManyTimes specified', () => {
+        var sex = 'f' 
+        expect(sb.catIf(sex === 'f', 'Hola World' ).bufferSize()).to.equal(1);
+    });
+
+     it('should add an string howManyTimes specified', () => {
+        var sex = 'm' 
+        expect(sb.catIf(sex === 'f', 'Hola World' ).bufferSize()).to.equal(0);
+    });
+});


### PR DESCRIPTION
**_Adding catIf method_**
```
It’s very common that you will need perform the string concatenation only 
if a constraint is satisfied.  The last argument of this method must be a boolean 
testable value that will indicate if the given strings shall be added or not.
```
`sb.catIf(sex === 'm', 'gentleman!' );`