### PR TITLE
StringBuilder adding wrap method

### DIFF
--- a/src/stringBuilder.js
+++ b/src/stringBuilder.js
@@ -2,10 +2,25 @@ require('./array-linq');
 
 StringBuilder = (function () {
     var buffer = [];
+    var wrappers = [];
+
+    var concatenate = function(...val){
+        val.flatten().each(obj => typeof obj === "function" ? concatenate([obj()]) : buffer.push(obj.toString()));
+    }
+
+    var addPrefix = function(){
+        wrappers.where(obj => obj.prefix.length > 0).each(obj => concatenate(obj.prefix));
+    }
+
+    var addSuffix = function(){
+        wrappers.where(obj => obj.suffix.length > 0).each(obj => concatenate(obj.suffix));
+    }
 
     return {
         cat: function (...val) {
-            val.flatten().each(obj => { typeof obj === "function" ? buffer.push(obj()) : buffer.push(obj) });
+            addPrefix();
+            concatenate(val);
+            addSuffix();
             return this;
         },
         bufferSize: function () {
@@ -13,6 +28,7 @@ StringBuilder = (function () {
         },
         clear: function () {
             buffer = [];
+            wrappers = [];
         },
         string: function () {
             return buffer.join('');
@@ -24,10 +40,14 @@ StringBuilder = (function () {
             }
             return this;
         },
-        catIf(flag, ...val){
+        catIf: function(flag, ...val){
             if(flag){
                 this.cat(val);
             }
+            return this;
+        },
+        wrap: function(pre, suf){
+            wrappers.push({ prefix: arguments[0], suffix: arguments[1]})            
             return this;
         }
     };

--- a/tests/stringBuilder/stringBuilder-catIf-test.js
+++ b/tests/stringBuilder/stringBuilder-catIf-test.js
@@ -5,18 +5,17 @@ var StringBuilder = require('./../../src/stringBuilder');
 var sb = StringBuilder
 
 
-describe('StringBuilder method catIf', () => {
-    
+describe('StringBuilder method catIf', () => { 
     afterEach(() => {
         sb.clear();
     });
 
-    it('should add an string howManyTimes specified', () => {
+    it('should add an string when condition is true', () => {
         var sex = 'f' 
         expect(sb.catIf(sex === 'f', 'Hola World' ).bufferSize()).to.equal(1);
     });
 
-     it('should add an string howManyTimes specified', () => {
+     it('should not add an string when condition is false', () => {
         var sex = 'm' 
         expect(sb.catIf(sex === 'f', 'Hola World' ).bufferSize()).to.equal(0);
     });

--- a/tests/stringBuilder/stringBuilder-string-test.js
+++ b/tests/stringBuilder/stringBuilder-string-test.js
@@ -6,7 +6,10 @@ var sb = StringBuilder
 
 
 describe('StringBuilder method string', () => {
-
+    afterEach(() => {
+        sb.clear();
+    });
+    
     it('should return the buffer concatenated', () => {
         
         expect(sb.cat('Hello ', 'World', ' !!!').string()).to.equal('Hello World !!!');

--- a/tests/stringBuilder/stringBuilder-wrap-test.js
+++ b/tests/stringBuilder/stringBuilder-wrap-test.js
@@ -1,0 +1,22 @@
+var chai = require('chai');
+var expect = chai.expect;
+var StringBuilder = require('./../../src/stringBuilder');
+
+var sb = StringBuilder;
+var count = 0;
+
+describe('StringBuilder method wrap', () => {
+    afterEach(() => {
+        sb.clear();
+    });
+
+    it('should add a prefix and suffix to every concatenation added', () => {
+        console.log(sb.string());
+        expect(sb.wrap('<', '>').rep(5, 'hello').string()).to.equal('<hello><hello><hello><hello><hello>');
+    });
+
+    it('should add a prefix and suffix and execute functions', () => {
+        console.log(sb.string());
+        expect(sb.wrap(['[', () => count += 1], ']').rep(5, '.-hello').string()).to.equal('[1.-hello][2.-hello][3.-hello][4.-hello][5.-hello]');
+    });
+});


### PR DESCRIPTION
**_Adding wrap method._**
```
Everything you add to StringBuilder after this method is called shall be surrounded by the prefix and suffix arguments. The prefix and suffix arguments would be any supported type (string, function to be called, any object that will be evaluated against toString() method) or an array containing a list of any supported type.
```
```
.js
```
`var sb = new StringBuilder();`
`sb.cat('<ul>', '\n')`
   ` .wrap('<li>', [‘</li>', '\n'])`
   ` .rep(10, 'list item', 10)`
   ` .cat('</ul>');`
