### PR TITLE
StringBuilder adding end method

### DIFF
--- a/src/stringBuilder.js
+++ b/src/stringBuilder.js
@@ -1,53 +1,57 @@
 require('./array-linq');
 
-StringBuilder = (function () {
+StringBuilder = (function() {
     var buffer = [];
     var wrappers = [];
 
-    var concatenate = function(...val){
+    var concatenate = function(...val) {
         val.flatten().each(obj => typeof obj === "function" ? concatenate([obj()]) : buffer.push(obj.toString()));
     }
 
-    var addPrefix = function(){
+    var addPrefix = function() {
         wrappers.where(obj => obj.prefix.length > 0).each(obj => concatenate(obj.prefix));
     }
 
-    var addSuffix = function(){
-        wrappers.where(obj => obj.suffix.length > 0).each(obj => concatenate(obj.suffix));
+    var addSuffix = function() {
+        wrappers.where(obj => obj.suffix.length > 0).reverse().each(obj => concatenate(obj.suffix));
     }
 
     return {
-        cat: function (...val) {
+        cat: function(...val) {
             addPrefix();
             concatenate(val);
             addSuffix();
             return this;
         },
-        bufferSize: function () {
+        bufferSize: function() {
             return buffer.length;
         },
-        clear: function () {
+        clear: function() {
             buffer = [];
             wrappers = [];
         },
-        string: function () {
+        string: function() {
             return buffer.join('');
         },
-        rep: function (howManyTimes, ...val) {
+        rep: function(howManyTimes, ...val) {
             var i;
-            for(i = 0; i< howManyTimes; i += 1){
+            for (i = 0; i < howManyTimes; i += 1) {
                 this.cat(val);
             }
             return this;
         },
-        catIf: function(flag, ...val){
-            if(flag){
+        catIf: function(flag, ...val) {
+            if (flag) {
                 this.cat(val);
             }
             return this;
         },
-        wrap: function(pre, suf){
-            wrappers.push({ prefix: arguments[0], suffix: arguments[1]})            
+        wrap: function(pre, suf) {
+            wrappers.push({ prefix: arguments[0], suffix: arguments[1] })
+            return this;
+        },
+        end: function(deep) {
+            (deep === null || deep === undefined) ? wrappers.pop() : wrappers.splice(wrappers.length - deep, deep);
             return this;
         }
     };

--- a/tests/stringBuilder/stringBuilder-end-test.js
+++ b/tests/stringBuilder/stringBuilder-end-test.js
@@ -1,0 +1,22 @@
+var chai = require('chai');
+var expect = chai.expect;
+var StringBuilder = require('./../../src/stringBuilder');
+
+var sb = StringBuilder;
+var count = 0;
+
+describe('StringBuilder method end', () => {
+    afterEach(() => {
+        sb.clear();
+    });
+
+    it('should remove last wrapper configuration', () => {
+        console.log(sb.string());
+        expect(sb.wrap(['[', () => count += 1], ']').rep(2, '.-hello').end().cat('World').string()).to.equal('[1.-hello][2.-hello]World');
+    });
+
+    it('should remove last deep wrappers', () => {
+        console.log(sb.string());
+        expect(sb.wrap('{', '}').wrap('[', ']').wrap('(', ')').rep(2, 'hello').end(2).cat('World').string()).to.equal('{[(hello)]}{[(hello)]}{World}');
+    });
+});


### PR DESCRIPTION
**_Adding end(deep) method_** 
```
This method is intended to cancel the current or last “effect” or “decorator” 
that were added to the StringBuilder by calling any of the following methods: 
wrap, prefix and suffix.
The not required deep parameter will allow you to cancel more than one effect, 
they work as an stack, so it will just pop the last deep pushed effects or only the last one if deep is null or undefined. 
```
```
.js
```
`sb.wrap(['[', () => count += 1], ']').rep(2, '.-hello').end().cat('World').string()`
