### PR TITLE
StringBuilder adding prefix method

### DIFF
--- a/src/stringBuilder.js
+++ b/src/stringBuilder.js
@@ -53,6 +53,10 @@ StringBuilder = (function() {
         end: function(deep) {
             (deep === null || deep === undefined) ? wrappers.pop() : wrappers.splice(wrappers.length - deep, deep);
             return this;
+        },
+        prefix: function(...pre){
+            wrappers.push({ prefix: pre, suffix: [] })
+            return this;
         }
     };
 } ());

--- a/tests/stringBuilder/stringBuilder-prefix-test.js
+++ b/tests/stringBuilder/stringBuilder-prefix-test.js
@@ -1,0 +1,23 @@
+var chai = require('chai');
+var expect = chai.expect;
+var StringBuilder = require('./../../src/stringBuilder');
+
+var sb = StringBuilder;
+var count = 0;
+
+describe('StringBuilder method prefix', () => {
+    afterEach(() => {
+        sb.clear();
+    });
+
+    it('should add a prefix to every concatenation added', () => {
+        
+        expect(sb.prefix('-').rep(5, 'hello ').string()).to.equal('-hello -hello -hello -hello -hello ');        
+    });
+
+    it('should add a prefix and suffix and execute functions', () => {
+        
+        expect(sb.prefix(() => count += 1, '.-').rep(2, 'hello ').string()).to.equal('1.-hello 2.-hello ');
+        console.log(sb.string());
+    });
+});

--- a/tests/stringBuilder/stringBuilder-wrap-test.js
+++ b/tests/stringBuilder/stringBuilder-wrap-test.js
@@ -11,12 +11,12 @@ describe('StringBuilder method wrap', () => {
     });
 
     it('should add a prefix and suffix to every concatenation added', () => {
-        console.log(sb.string());
+        
         expect(sb.wrap('<', '>').rep(5, 'hello').string()).to.equal('<hello><hello><hello><hello><hello>');
     });
 
     it('should add a prefix and suffix and execute functions', () => {
-        console.log(sb.string());
+        
         expect(sb.wrap(['[', () => count += 1], ']').rep(5, '.-hello').string()).to.equal('[1.-hello][2.-hello][3.-hello][4.-hello][5.-hello]');
     });
 });


### PR DESCRIPTION
**_Adding prefix(arg1, arg2,..., argN) method_** 
As it happened with the wrap method, everything added after calling this method shall be prefixed with the specified arguments. If you want you can see this method as a shorthand for a wrapper that have no right parameter.
In other words, calling prefix must have the same result as calling wrap(‘left’, []).
```
```
```
.js
```
`sb.prefix('-').rep(5, 'hello ').string()`
