### PR TITLE
StringBuilder adding suffix method

### DIFF
--- a/src/stringBuilder.js
+++ b/src/stringBuilder.js
@@ -57,6 +57,10 @@ StringBuilder = (function() {
         prefix: function(...pre){
             wrappers.push({ prefix: pre, suffix: [] })
             return this;
+        },
+        suffix: function(...suf){
+            wrappers.push({ prefix: [], suffix: suf })
+            return this;
         }
     };
 } ());

--- a/tests/stringBuilder/stringBuilder-prefix-test.js
+++ b/tests/stringBuilder/stringBuilder-prefix-test.js
@@ -15,9 +15,8 @@ describe('StringBuilder method prefix', () => {
         expect(sb.prefix('-').rep(5, 'hello ').string()).to.equal('-hello -hello -hello -hello -hello ');        
     });
 
-    it('should add a prefix and suffix and execute functions', () => {
+    it('should add a prefix and execute functions', () => {
         
-        expect(sb.prefix(() => count += 1, '.-').rep(2, 'hello ').string()).to.equal('1.-hello 2.-hello ');
-        console.log(sb.string());
+        expect(sb.prefix(() => count += 1, '.-').rep(2, 'hello ').string()).to.equal('1.-hello 2.-hello ');        
     });
 });

--- a/tests/stringBuilder/stringBuilder-suffix-test.js
+++ b/tests/stringBuilder/stringBuilder-suffix-test.js
@@ -1,0 +1,22 @@
+var chai = require('chai');
+var expect = chai.expect;
+var StringBuilder = require('./../../src/stringBuilder');
+
+var sb = StringBuilder;
+var count = 0;
+
+describe('StringBuilder method suffix', () => {
+    afterEach(() => {
+        sb.clear();
+    });
+
+    it('should add a suffix to every concatenation added', () => {
+        
+        expect(sb.suffix('-').rep(5, ' hello').string()).to.equal(' hello- hello- hello- hello- hello-');        
+    });
+
+    it('should add a suffix and execute functions', () => {
+        
+        expect(sb.suffix('= ', () => count += 1, ' ' ).rep(2, 'hello ').string()).to.equal('hello = 1 hello = 2 ');        
+    });
+});


### PR DESCRIPTION
**_suffix(arg1, arg2,..., argN) method._**
```
As it happened with the wrap method, everything added after calling this method shall be suffixed with the specified arguments. If you want you can see this method as a shorthand for a wrapper that have no left parameter.
In other words, calling suffix must have the same result as calling wrap([], 'right').
```
```
```
.js
```
```
```
`sb.prefix('-').rep(5, 'hello ').string()`
