### PR TITLE
StringBuilder adding when method

### DIFF
--- a/src/stringBuilder.js
+++ b/src/stringBuilder.js
@@ -65,6 +65,9 @@ StringBuilder = (function() {
         each: function(array, spec) {
             array.each((value, index) => spec.call(this, value, index, array));
             return this;
+        },
+        when: function(spec, then, otherWise){
+            (spec) ? this.cat(then) : this.cat(otherWise);
         }
     };
 } ());

--- a/src/stringBuilder.js
+++ b/src/stringBuilder.js
@@ -68,6 +68,7 @@ StringBuilder = (function() {
         },
         when: function(spec, then, otherWise){
             (spec) ? this.cat(then) : this.cat(otherWise);
+            return this;
         }
     };
 } ());

--- a/tests/stringBuilder/stringBuilder-each-test.js
+++ b/tests/stringBuilder/stringBuilder-each-test.js
@@ -9,7 +9,7 @@ var sb = StringBuilder;
 var count = 0;
 
 
-var funcTest2 = function(dev){
+var funcConcat = function(dev){
     this.cat('[', dev.name, ']');
 };
 
@@ -20,7 +20,7 @@ describe('StringBuilder method each', () => {
 
     it('should iterate over array', () => {
     
-        expect(sb.each(developers, funcTest2 ).string()).to.equal('[pedro][juan][pablo]');        
+        expect(sb.each(developers, funcConcat ).string()).to.equal('[pedro][juan][pablo]');        
     });
 
 });

--- a/tests/stringBuilder/stringBuilder-when-test.js
+++ b/tests/stringBuilder/stringBuilder-when-test.js
@@ -1,0 +1,26 @@
+var chai = require('chai');
+var expect = chai.expect;
+var StringBuilder = require('./../../src/stringBuilder');
+var mocks = require('./../../mocks/mocks.json');
+var developers = mocks.developers;
+
+
+var sb = StringBuilder;
+var count = 0;
+
+
+var funcConcat = function (dev) {
+    this.when(dev.age <= 23, ['[', dev.name, ' is joung],'], ['[', dev.name, ' is old]'])
+};
+
+describe('StringBuilder method when', () => {
+    afterEach(() => {
+        sb.clear();
+    });
+
+    it('should concate depending on the evalueation thenArgs or otherwiseArgs', () => {
+
+        expect(sb.each(developers, funcConcat).string()).to.equal('[pedro is old][juan is joung],[pablo is old]');
+    });
+
+});


### PR DESCRIPTION
**_when(expression, thenArgs, otherwiseArgs)_** 

> This method must evaluate the expression and call the cat() method with the thenArgs or otherwiseArgs depending on the result of evaluation. If the expression is a function then if must be called and its result will be used to determine the path to choose.
```
.js
```
`sb.each(developers, funcConcat).string()`
